### PR TITLE
Change load calls to safe_load so that PyYAML >= 6.0 works

### DIFF
--- a/lttngutils/profile.py
+++ b/lttngutils/profile.py
@@ -53,7 +53,7 @@ class Profile:
         if (evfile is None):
             logging.warning("tracing profile " + name + " not found")
             return None
-        profile = yaml.load(open(evfile))
+        profile = yaml.safe_load(open(evfile))
         if "ust" not in profile:
             profile["ust"] = []
         if "jul" not in profile:
@@ -94,7 +94,7 @@ class Profile:
                     if (filename.endswith(".profile")):
                         profile_name = re.sub('\.profile$', '', filename)
                         if profile_name not in profiles:
-                            profile = yaml.load(open(dirname + filename))
+                            profile = yaml.safe_load(open(dirname + filename))
                             if (profile is not None):
                                 profile["file"] = dirname + filename
                                 profiles[profile_name] = profile


### PR DESCRIPTION
PyYAML depecrated the default Loader argument in the load function because it was unsafe. In the latest 6.0 version the argument is now required and it breaks the lttng-record-trace script.

This commit replaces the load call to safe_load that uses a subset of full_load (which is what was used as default in previous versions) but profiles do not use any extensive syntax so it is not necessary to use a different loader.

Signed-off-by: Arnaud Fiorini <fiorini.arnaud@gmail.com>