### PR TITLE
Use https:// instead of removed git://

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install LTTng utils directly from the git repository
 3. Use ``pip3`` to install LTTng analyses:
 
 ```
-$ sudo pip3 install --upgrade git+git://github.com/tahini/lttng-utils.git@master
+$ sudo pip3 install --upgrade git+https://github.com/tahini/lttng-utils.git@master
 ```
 
 ### Usage


### PR DESCRIPTION
git:// has been removed from github:

https://github.blog/2021-09-01-improving-git-protocol-security-github/

This change appears to work - I ran through https://github.com/tuxology/tracevizlab/tree/master/labs/003-record-kernel-trace-lttng and it was fine. I will have a separate PR for updating tracevizlab soon.